### PR TITLE
Clarify reference to `open-source-and-design.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Open with Design
 ## Thoughts on Open Design / Dev-Design Workflows / Open Source
 
-This document spawned from a combination of in person sessions held at Kiwi Foo camp and Open Source Open Society around:
+[This document](open-source-and-design.md) spawned from a combination of in person sessions held at Kiwi Foo camp and Open Source Open Society around:
 * Lowering the barrier to entry (into Open Source) - How to get more non-code contributions in open source?
 * Looking at the different layers of what 'open' means in a design context - Open Sourcing your design vs Designing in the Open vs Designing for an Open Source Software project vs Open Source tools for producing design
 * Connections - how do we get developers and designers to collabortate more effectivly on Open Source Software projects? Things such as onboarding processes and getting non-technical people using Github. What tools does your project use and are these limiting people that can contribute? What tools can designers use for collaborative work processes?


### PR DESCRIPTION
When I first read this I didn't realise that the document being referred to was `open-source-and-design.md` rather than the README itself.
